### PR TITLE
Expand schema to allow upload of raster data with spatial resolution of 4km and 0.25-degree

### DIFF
--- a/core/climate.mcf
+++ b/core/climate.mcf
@@ -63,6 +63,18 @@ subClassOf: schema:Place
 name: "GeoGridPlace_1Deg"
 description: "A place representing a uniform 1x1 degree grid on the surface of the Earth. Unlike IPCCPlace entities, these are not defined in the context of a country."
 
+Node: dcid:GeoGridPlace_025Deg
+typeOf: schema:Class
+subClassOf: schema:Place
+name: "GeoGridPlace_025Deg"
+description: "A place representing a uniform 0.25x0.25 degree grid on the surface of the Earth; contained in US Counties."
+
+Node: dcid:GeoGridPlace_4KM
+typeOf: schema:Class
+subClassOf: schema:Place
+name: "GeoGridPlace_4KM"
+description: "A place representing a uniform 4km grid on the surface of the Earth; contained in US counties."
+
 ## Properties
 
 Node: dcid:heavyPrecipitationIndex


### PR DESCRIPTION
Expand the [initial](https://github.com/datacommonsorg/data/issues/694) county-level RFF Weather Variability dataset to include:
1) historical weather variability statistics from the same time period (1981-2021) at more granular spatial resolution (4km rasters rather than county-level data)
2) forecasted values of the same weather variability statistics using a different data-source dating from 2006-2099 at 0.25-degree spatial resolution (county-level aggregation to be done on the Google side after upload).