### PR TITLE
Add mcf for exchange rate and currency schemas

### DIFF
--- a/core/dcschema.mcf
+++ b/core/dcschema.mcf
@@ -2858,3 +2858,20 @@ Node: dcid:Portion
 typeOf: dcs:UnitOfMeasure
 name: "Portion"
 description: "A unit of measure used to measure serving of food."
+
+Node: dcid:exchangeRate
+typeOf: schema:Property
+name: "exchangeRate"
+description: "The exchange rate of a currency compared to another currency."
+domainIncludes: schema:Currency
+rangeIncludes:UnitPriceSpecification
+
+Node: dcid: currencyIsoCode
+typeOf: schema:Property
+name: "currencyIsoCode"
+description: "The current Iso 4217 code assigned to a currency unit."
+domainIncludes: Currency
+rangeIncludes: Text
+
+
+

--- a/core/dcschema.mcf
+++ b/core/dcschema.mcf
@@ -2873,5 +2873,9 @@ description: "The current Iso 4217 code assigned to a currency unit."
 domainIncludes: Currency
 rangeIncludes: Text
 
-
-
+Node: dcid:usesCurrency
+typeOf: schema:Property
+name: "usesCurrency"
+description: "The unit of currency currently used by a Place."
+domainIncludes: schema:Place
+rangeIncludes: dcs: CurrencyUnitOfMeasure

--- a/core/dcschema_enum_classes.mcf
+++ b/core/dcschema_enum_classes.mcf
@@ -418,3 +418,16 @@ Node: dcid:ClimaticSeasonEnum
 typeOf: schema:Class
 subClassOf: schema:Enumeration
 name: "ClimaticSeasonEnum"
+
+Node: dcid:CurrencyUnitStandardizationEnum
+typeOf: schema:Class
+subClassOf: schema:Enumeration
+description: "Identifies whether the currency of a region is represented in the currency of the observation period (LocalCurrency), or the current currency of the region (Standardized)."
+name: "CurrencyUnitStandardizationEnum"
+
+Node: dcid:Currency
+typeOf: schema:Class
+subClassOf: schema:CurrencyUnitOfMeasure
+description: "An official world currency as determined by the ISO 4217 currency list."
+name: "Currency"
+

--- a/core/dcschema_enum_instances.mcf
+++ b/core/dcschema_enum_instances.mcf
@@ -2185,3 +2185,11 @@ typeOf: dcs:FBI_MeasurementQualifierEnum
 Node: dcid:SummerSeason
 name: "SummerSeason"
 typeOf: dcs:ClimaticSeasonEnum
+
+Node: dcid:LocalCurrency
+name: "LocalCurrency"
+typeOf: dcs:CurrencyUnitStandardizationEnum
+
+Node: dcid:StandardizedCurrency
+name: "StandardizedCurrency"
+typeOf: dcs:CurrencyUnitStandardizationEnum

--- a/stat_vars/fao_exchange_rate_currency_stat_vars.mcf
+++ b/stat_vars/fao_exchange_rate_currency_stat_vars.mcf
@@ -1,0 +1,11 @@
+Node: dcid:ExchangeRate_Currency_Local
+populationType: dcs:Currency
+measuredProperty: dcs:exchangeRate
+statType: dcs:measuredValue
+measurementQualifier: dcs:CurrencyUnitStandardizationEnum
+
+Node: dcid:ExchangeRate_Currency_Standardized
+populationType: dcs:Currency
+measuredProperty: dcs:exchangeRate
+statType: dcs:measuredValue
+measurementQualifier: dcs:CurrencyUnitStandardizationEnum


### PR DESCRIPTION
Detailed info on schema can be found [here](https://docs.google.com/document/d/11mjxUe5UQOHF1vz_kCDFw3cqBXk8_WOM2QuCgxZFiVo/edit#heading=h.f9cam3i0r6g5).  

Created stat var mcf file for exchange rate of currency schemas for both local exchange rate and standardized exchange rate.

Added 2 new DC enum classes: Currency and CurrencyUnitStandardizationEnum. Note that once schema.org refactor is done for ExchangeRateSpecification (which corresponds to this entity Currency in DC), we can move the Currency node to the core/schema.mcf file.

Added 2 enum instances, LocalCurrency and StandardizedCurrency. Enum instances for Currency will be in follow up PR.

Added usesCurrency as DC property to dcschema.mcf until refactor of currency into usesCurrency on schema.org takes place. After that, can edit currency property in core/schema.mcf to reflect new name.

Added 2 new DC properties to dcschema.mcf: exchangeRate and currencyIsoCode.