### PR TITLE
added a new statistical variable for soil drought measurements

### DIFF
--- a/stat_vars/cdc_stat_vars.mcf
+++ b/stat_vars/cdc_stat_vars.mcf
@@ -93,6 +93,12 @@ populationType: dcs:Atmosphere
 measuredProperty: dcs:standardizedPrecipitationIndex
 statType: dcs:measuredValue
 
+Node: dcid:StandardizedPrecipitationIndex_Soil
+typeOf: dcs:StatisticalVariable
+populationType: dcid:Soil
+measuredProperty: dcs:standardizedPrecipitationIndex
+statType: dcs:measuredValue
+
 Node: dcid:StandardizedPrecipitationEvapotranspirationIndex_Atmosphere
 typeOf: dcs:StatisticalVariable
 populationType: dcs:Atmosphere


### PR DESCRIPTION
I aim to add data from[ European environmental agency about soil drought](https://www.eea.europa.eu/en/datahub/datahubitem-view/c7c868d8-95dc-4f23-9dde-4cdc2738cc4d) into datacommons and I need an statistical variable to report the observation of the dataset. in this pull request I added this statvar. please let me know about your comments.